### PR TITLE
Remove strong naming for now

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,8 +26,11 @@
     <!-- Local builds should embed PDBs so we never lose them when a subsequent build occurs. -->
     <DebugType Condition=" '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">embedded</DebugType>
 
+    <!-- Don't strong name currently, since Tempest isn't strong named -->
+    <!--
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)strongname.snk</AssemblyOriginatorKeyFile>
+    -->
 
     <PackageProjectUrl>https://github.com/BretJohnson/visual-test-utils</PackageProjectUrl>
     <Company>Microsoft Corporation</Company>


### PR DESCRIPTION
We can't strong name since Tempest isn't
strong named. We'll probably add this back
once that changes.